### PR TITLE
Update .gitignore for docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+/docs
+!/docs/.nojekyll


### PR DESCRIPTION
## Summary
- ensure `.gitignore` ignores the `docs/` folder while keeping `docs/.nojekyll`

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: TS2322 error)*


------
https://chatgpt.com/codex/tasks/task_e_6847ccb1899c8332b10e60ffa5a2270f