### PR TITLE
Add export script for static build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",
+    "export": "next build && next export -o docs",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- add an `export` npm script to build static output into the `docs` folder

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b11deac8332ad2506ce31caad15