### PR TITLE
Fix ref callback return type

### DIFF
--- a/src/components/causalflow/PathDiagram.tsx
+++ b/src/components/causalflow/PathDiagram.tsx
@@ -332,7 +332,9 @@ export default function PathDiagram({ variables, numPeriods, paths, onPathsChang
               return (
                 <VariableNode
                   key={nodeId}
-                  ref={el => nodeRefs.current.set(nodeId, el)}
+                  ref={el => {
+                    nodeRefs.current.set(nodeId, el);
+                  }}
                   variableName={variable.name}
                   nodeId={nodeId}
                   onClick={() => handleNodeClick(variable.id, periodIndex)}


### PR DESCRIPTION
## Summary
- fix TypeScript type error in PathDiagram ref callback

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684e53d999c08332ba3fc37bdba2e8f0