### PR TITLE
Update documentation after refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 CausalFlow is a web application for building causal path diagrams over multiple time periods. It lets you define variables, connect them across time, and export a lavaan syntax file for structural equation modeling.
 
+Built with **Next.js 15**, **React 18** and **TypeScript**, it uses Tailwind CSS for styling and shadcn/ui components.
+
 ## Features
 
 - **Variable input** – Add and name variables that will appear in the diagram.
 - **Time period setup** – Specify the number of measurement periods.
-- **Interactive path diagram** – Click and drag between nodes to create causal links. Connections are limited to the same period or the following period.
+- **Interactive path diagram** – Click on a variable and then another to draw a directed arrow. Links between different variables are restricted to the same period or the following one. Self‑loops may span multiple periods. Skipping connections within a period are drawn with elbowed lines that automatically take unused lanes to avoid overlap.
 - **Lavaan export** – Download the model in lavaan format so it can be used in R for further analysis.
 
 ## Project structure
@@ -18,6 +20,7 @@ src/
   lib/               Utility helpers including lavaan exporter
   hooks/             React hooks
   types/             Type definitions
+  ai/                Genkit flows and configuration
 ```
 
 ## Getting started
@@ -35,6 +38,10 @@ src/
    ```bash
    npm run typecheck
    npm run lint
+   ```
+4. (Optional) Run Genkit AI flows:
+   ```bash
+   npm run genkit:dev
    ```
 
 ## Building and deployment

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -5,7 +5,7 @@
 - Variable Input: Add and name variables for the path diagram.
 - Period Definition: Define the number of time periods for variable measurement.
 - Tabular Display: Display a tabular layout showing variables measured at each time period.
-- Path Definition: Visually connect variables to define causal paths by clicking and dragging. A narrow line should appear between variable boxes, allowing connections only to variables in the same time period or the next. When the user clicks on one of the variables, then they move the mouse and an arrow moves with the mouse until they click again in a different box and a link is created and the arrow becomes static and is displayed.
+- Path Definition: Visually connect variables by clicking one node and then another. Links between different variables may target the same period or the immediate next period. Self-loops can span multiple periods. When skipping over other variables in a period, elbow connectors are placed in separate lanes to avoid overlap.
 - Lavaan Export: Download the defined path model in lavaan-compatible format.
 
 ## Style Guidelines:

--- a/documentation/deploy-steps.md
+++ b/documentation/deploy-steps.md
@@ -6,7 +6,7 @@ This guide explains how to publish the static build of **CausalFlow** to GitHub 
    ```bash
    npm ci
    ```
-   Make sure you have Node.js installed. The command above installs all packages in a reproducible way.
+   Make sure you have **Node.js 20** or later installed. The command above installs all packages in a reproducible way.
 
 2. **Generate the static site**
    ```bash


### PR DESCRIPTION
## Summary
- clarify Next.js/React/TypeScript usage in README
- document new diagram connection rules and Genkit entrypoint
- update blueprint with current path drawing logic
- note Node.js requirement in deploy steps

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684e5555d67c8332a427501ca0ea6f80